### PR TITLE
[feat] 팝업 외부 클릭 시 닫힘 기능 구현

### DIFF
--- a/src/Pages/Main.tsx
+++ b/src/Pages/Main.tsx
@@ -1,17 +1,21 @@
+import { useResetRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import { SideTab } from '@/components/Filter/SideTab/SideTab';
 import { Header } from '@/components/Header';
 import { Card } from '@/components/Product/Card/Card';
 import { MainInput } from '@/components/Search/MainInput';
+import { popUpOpenState } from '@/recoils/popUp/popUp';
 
 export function Main() {
+  const closeWholePopUp = useResetRecoilState(popUpOpenState);
+
   return (
     <>
-      <StyledHeader>
+      <StyledHeader onClick={closeWholePopUp}>
         <Header />
       </StyledHeader>
-      <StyledMain>
+      <StyledMain onClick={closeWholePopUp}>
         <SearchSection>여기는</SearchSection>
         <MainInput />
         <MainContents>
@@ -27,7 +31,7 @@ export function Main() {
           />
         </MainContents>
       </StyledMain>
-      <StyledAside>
+      <StyledAside onClick={closeWholePopUp}>
         <SideTab />
       </StyledAside>
       <footer>푸터</footer>

--- a/src/components/Header/Popup.tsx
+++ b/src/components/Header/Popup.tsx
@@ -1,22 +1,29 @@
-import { useState } from 'react';
+import { useRecoilState, useResetRecoilState } from 'recoil';
 
 import { Text } from '@/components/common';
+import { popUpOpenState, defaultPopUpOpenState } from '@/recoils/popUp/popUp';
 
 import * as S from './popUp.style';
 import * as Types from './popUp.types';
 
-export function PopUp({ title, options }: Types.LinkProps) {
-  const [isClicked, setClicked] = useState(false);
+export function PopUp({ title, options, id }: Types.PopUpProps) {
+  const [isOpen, setIsOpen] = useRecoilState(popUpOpenState);
 
   const MenuList = options.map(option => <Text as="li">{option}</Text>);
   return (
     <S.Select
-      onClick={() => {
-        setClicked(!isClicked);
+      onClick={e => {
+        e.stopPropagation();
       }}
     >
-      <Text>{title}</Text>
-      <S.Menu isVisible={isClicked}>{MenuList}</S.Menu>
+      <Text
+        onClick={() => {
+          setIsOpen({ ...defaultPopUpOpenState, [id]: true });
+        }}
+      >
+        {title}
+      </Text>
+      <S.Menu isVisible={isOpen[id]}>{MenuList}</S.Menu>
     </S.Select>
   );
 }

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,22 +1,30 @@
 import { Icon } from '@/components/common';
 import { IconTypes } from '@/components/common/Icon/types';
+import { defaultPopUpOpenState } from '@/recoils/popUp/popUp';
 
 import * as S from './header.styles';
 import { PopUp } from './Popup';
 
 const USER_ICON_LIST: IconTypes[] = ['MENU', 'SHOPPING_CART', 'PERSON'];
 
+const NAV_DATA_LIST: {
+  title: string;
+  options: string[];
+  id: keyof typeof defaultPopUpOpenState;
+}[] = [
+  { title: '페이지', options: ['홈', '메인'], id: 0 },
+  {
+    title: 'QnA',
+    options: ['고객 안내', '자주 묻는 질문', '1대1 고객상담'],
+    id: 1,
+  },
+];
+
 const UserIcons = USER_ICON_LIST.map(icon => (
   <Icon iconSrc={icon} key={icon} />
 ));
-
-const NAV_DATA_LIST: { title: string; options: string[] }[] = [
-  { title: '페이지', options: ['홈', '메인'] },
-  { title: 'QnA', options: ['고객 안내', '자주 묻는 질문', '1대1 고객상담'] },
-];
-
-const NAV_CONTENTS = NAV_DATA_LIST.map(({ title, options }) => (
-  <PopUp title={title} options={options} />
+const NAV_CONTENTS = NAV_DATA_LIST.map(({ title, options, id }) => (
+  <PopUp title={title} options={options} id={id} />
 ));
 
 export function Header() {

--- a/src/components/Header/popUp.types.ts
+++ b/src/components/Header/popUp.types.ts
@@ -1,4 +1,10 @@
-export type LinkProps = { title: string; options: string[] };
+import { defaultPopUpOpenState } from '@/recoils/popUp/popUp';
+
+export type PopUpProps = {
+  title: string;
+  options: string[];
+  id: keyof typeof defaultPopUpOpenState;
+};
 
 export type MenuProps = {
   isVisible: boolean;

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -2,7 +2,6 @@ import { forwardRef, Ref, ElementType } from 'react';
 
 import { StyledInput } from './style';
 import { InputProps } from './types';
-// 폰트사이즈 , 패딩, 플레이스 홀더
 
 function Input<incomElementType extends ElementType = 'input'>(
   {

--- a/src/recoils/popUp/popUp.ts
+++ b/src/recoils/popUp/popUp.ts
@@ -1,5 +1,6 @@
 import { atom } from 'recoil';
 
+// TODO: 상수 리팩토링시 헤더의 팝업 상태를 reduce해서 기본값을 생성하는 식으로 리팩토링 가능
 export const defaultPopUpOpenState = { 0: false, 1: false };
 
 export const popUpOpenState = atom({

--- a/src/recoils/popUp/popUp.ts
+++ b/src/recoils/popUp/popUp.ts
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+export const defaultPopUpOpenState = { 0: false, 1: false };
+
+export const popUpOpenState = atom({
+  key: 'popUpOpenState',
+  default: defaultPopUpOpenState,
+});


### PR DESCRIPTION
## 작업 사항

* 팝업창은 외부를 클릭할시 자동으로 닫힌다.

* 팝업창이 열린 상태에서 다른 이벤트 요소를 클릭 할 경우 에도 팝업창은 바로닫히고 클릭 된 이벤트 요소가 실행 된다.

* 팝업창은 팝업창 내부요소를 클릭 할 경우 닫히지 않는다. 단 팝업창 트리거를 클릭 했을 경우에는 정상적으로 닫힌다. 

## 기타 

* 팝업창 여닫힘 상태 아톰 차후 상수 리팩토링시 헤더 네브 상수를 reduce하는 것으로 하드코딩 제거 가능