### PR TITLE
Purchase page authorization

### DIFF
--- a/src/Pages/Login/index.tsx
+++ b/src/Pages/Login/index.tsx
@@ -14,6 +14,10 @@ export function LoginPage() {
     setNeedSignIn(!needSignIn);
   };
 
+  const closeModal = () => {
+    setIsDone(false);
+  };
+
   return (
     <Layout>
       <LoginSection routeToSignIn={needSignIn}>
@@ -27,13 +31,8 @@ export function LoginPage() {
 
       <Introduce />
       <AlertModal isDone={isDone}>
-        <Text>{message}메시지 들어감</Text>
-        <Button
-          size="medium"
-          onClick={() => {
-            setIsDone(false);
-          }}
-        >
+        <Text>{message}</Text>
+        <Button size="medium" onClick={closeModal}>
           모달창 닫기
         </Button>
       </AlertModal>

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -24,3 +24,8 @@ export const postData = async <T>(
   const data = await axios.post<T>(URL, updatedData, { headers });
   return data;
 };
+
+export const getData = async (path: string) => {
+  const result = await axios.get(path);
+  return result.data;
+};

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -13,7 +13,7 @@ import axios from 'axios';
 // };
 export type HeaderType = {
   'Access-Token': any;
-  withCredentials: boolean;
+  withCredentials?: boolean;
 };
 
 export const postData = async <T>(

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -11,8 +11,16 @@ import axios from 'axios';
 //     zipCode: string;
 //   };
 // };
+export type HeaderType = {
+  'Access-Token': any;
+  withCredentials: boolean;
+};
 
-export const postData = async <T>(URL: string, updatedData: T) => {
-  const data = await axios.post<T>(URL, updatedData);
+export const postData = async <T>(
+  URL: string,
+  updatedData: T,
+  headers?: HeaderType,
+) => {
+  const data = await axios.post<T>(URL, updatedData, { headers });
   return data;
 };

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -25,7 +25,9 @@ export const postData = async <T>(
   return data;
 };
 
-export const getData = async (path: string) => {
-  const result = await axios.get(path);
-  return result.data;
-};
+export const getData =
+  <T>(path: string) =>
+  async () => {
+    const result = await axios.get(path);
+    return result.data as T;
+  };

--- a/src/components/server/Product/Card/index.tsx
+++ b/src/components/server/Product/Card/index.tsx
@@ -147,7 +147,7 @@ export function Card({ productId }: CardProps) {
     >
       <S.StyledCard
         onClick={() => {
-          navigate(`detail?id=${productId}`);
+          navigate(`/detail?id=${productId}`);
         }}
       >
         <Content isDisplay={isHover} content={contents[productId]} />

--- a/src/components/server/ProductDetail/OrderForm/Decide/Decide.tsx
+++ b/src/components/server/ProductDetail/OrderForm/Decide/Decide.tsx
@@ -4,16 +4,22 @@ import { Text } from '@/components/common';
 import { TextProps } from '@/components/common/Text/types';
 
 type decideType = {
-  finalPrice: string;
-  isFormFilled: boolean;
-  postOrder: () => void;
+  state: {
+    finalPrice: string;
+    isFormFilled: boolean;
+  };
+  func: {
+    postOrder: () => void;
+  };
 };
 
 type decideProps = {
   decide: decideType;
 };
 export function Decide({ decide }: decideProps) {
-  const { finalPrice, isFormFilled, postOrder } = decide;
+  const { state, func } = decide;
+  const { finalPrice, isFormFilled } = state;
+  const { postOrder } = func;
 
   return (
     <PriceAndButton>

--- a/src/components/server/ProductDetail/OrderForm/Decide/Decide.tsx
+++ b/src/components/server/ProductDetail/OrderForm/Decide/Decide.tsx
@@ -1,0 +1,53 @@
+import styled from 'styled-components';
+
+import { Text } from '@/components/common';
+import { TextProps } from '@/components/common/Text/types';
+
+type decideType = {
+  finalPrice: string;
+  isFormFilled: boolean;
+  postOrder: () => void;
+};
+
+type decideProps = {
+  decide: decideType;
+};
+export function Decide({ decide }: decideProps) {
+  const { finalPrice, isFormFilled, postOrder } = decide;
+
+  return (
+    <PriceAndButton>
+      <DiscountedPrice>{`총 ${finalPrice} 원`}</DiscountedPrice>
+      <PurchaseButton
+        disabled={!isFormFilled}
+        isFormFilled={isFormFilled}
+        onClick={postOrder}
+      >
+        <Text>구매</Text>
+      </PurchaseButton>
+    </PriceAndButton>
+  );
+}
+const PriceAndButton = styled.div`
+  width: 100%;
+  height: 60px;
+  display: flex;
+  justify-content: right;
+  align-items: center;
+  gap: 20px;
+`;
+
+type PurchaseProps = {
+  isFormFilled: boolean;
+};
+
+const PurchaseButton = styled.button<PurchaseProps>`
+  width: 70%;
+  height: 100%;
+  text-decoration: none;
+  border: none;
+  background: ${({ theme, isFormFilled }) =>
+    isFormFilled ? theme.pallete.primary : theme.pallete.grey4};
+  border-radius: 10px;
+`;
+const DiscountedPrice = styled(Text)<TextProps<'span'>>``;

--- a/src/components/server/ProductDetail/OrderForm/Info/index.tsx
+++ b/src/components/server/ProductDetail/OrderForm/Info/index.tsx
@@ -1,0 +1,132 @@
+import styled from 'styled-components';
+
+import { Discount } from '@/apis/mainProducts';
+import { Text } from '@/components/common';
+import { TextProps } from '@/components/common/Text/types';
+
+export type InfoType = {
+  imageUrl: string;
+  title: string;
+  brandName: string;
+  salePriceWithComma: string;
+  discounts: Discount;
+  productTotalPrice: number;
+};
+
+type InfoProps = {
+  info: InfoType;
+};
+
+export function Info({ info }: InfoProps) {
+  const {
+    imageUrl,
+    title,
+    brandName,
+    salePriceWithComma: salePrice,
+    discounts,
+    productTotalPrice,
+  } = info;
+
+  const originPrice = !!discounts.length && (
+    <OriginPrice styles={{ color: 'grey', fontSize: '10px' }} forwardedAs="del">
+      {productTotalPrice.toLocaleString()}
+    </OriginPrice>
+  );
+  const discountRate = !!discounts.length && (
+    <DiscountRate color="warning">
+      {discounts.length &&
+        `${
+          discounts.reduce((acc, curr) => {
+            return {
+              ...acc,
+              saleRate: String(+acc.saleRate + +curr.saleRate),
+            };
+          }).saleRate
+        }%`}
+    </DiscountRate>
+  );
+  return (
+    <InfoWrap>
+      <ProductImage src={imageUrl} />
+      <ProductDetail>
+        <InfoLeft>
+          <ProductInfo>
+            <Title>{title}</Title>
+            <Brand>{brandName}</Brand>
+          </ProductInfo>
+        </InfoLeft>
+        <InfoRight>
+          <PriceCompare>
+            {originPrice}
+            <DiscountedPrice>{`${salePrice} 원`}</DiscountedPrice>
+          </PriceCompare>
+          {discountRate}
+        </InfoRight>
+      </ProductDetail>
+    </InfoWrap>
+  );
+}
+
+const InfoWrap = styled.div`
+  width: 100%;
+  display: flex;
+  gap: 10px;
+`;
+const ProductDetail = styled.section`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+`;
+
+const InfoLeft = styled.div`
+  display: flex;
+  padding: 10px 0px;
+  gap: 10px;
+  height: 100px; ;
+`;
+
+const ProductImage = styled.img`
+  width: 150px;
+  height: 100px;
+`;
+
+const ProductInfo = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 5px;
+`;
+
+const Title = styled(Text)`
+  font-size: 10px;
+  font-weight: 300;
+  color: ${({ theme }) => theme.pallete.grey3};
+`;
+
+const Brand = styled(Text)`
+  font-size: 10px;
+  font-weight: 300;
+  color: ${({ theme }) => theme.pallete.grey3};
+`;
+
+const InfoRight = styled.div`
+  display: flex;
+  padding: 10px 0px;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 5px;
+`;
+
+const PriceCompare = styled.div`
+  display: flex;
+  gap: 5px;
+`;
+
+const OriginPrice = styled(Text)<TextProps<'del'>>`
+  margin-bottom: 10px;
+  font-weight: 500;
+`;
+
+const DiscountedPrice = styled(Text)<TextProps<'span'>>``;
+const DiscountRate = styled(Text)<TextProps<'span'>>``;

--- a/src/components/server/ProductDetail/OrderForm/index.style.ts
+++ b/src/components/server/ProductDetail/OrderForm/index.style.ts
@@ -14,7 +14,7 @@ export const Dimmed = styled.div<{ isClicked: boolean }>`
   height: 100vh;
   background: rgba(0, 0, 0, 0.5);
 `;
-
+export const DiscountedPrice = styled(Text)<TextProps<'span'>>``;
 export const PurchaseWrap = styled.div<{ isClicked: boolean }>`
   display: ${({ isClicked }) => (isClicked ? 'flex' : 'none')};
   position: fixed;
@@ -35,66 +35,6 @@ export const ProductDetail = styled.section`
   width: 100%;
   justify-content: space-between;
 `;
-
-export const DiscountRate = styled(Text)<TextProps<'span'>>``;
-
-export const InfoWrap = styled.div`
-  width: 100%;
-  display: flex;
-  gap: 10px;
-`;
-
-export const InfoLeft = styled.div`
-  display: flex;
-  padding: 10px 0px;
-  gap: 10px;
-  height: 100px; ;
-`;
-
-export const ProductImage = styled.img`
-  width: 150px;
-  height: 100px;
-`;
-
-export const ProductInfo = styled.div`
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  gap: 5px;
-`;
-
-export const Title = styled(Text)`
-  font-size: 10px;
-  font-weight: 300;
-  color: ${({ theme }) => theme.pallete.grey3};
-`;
-
-export const Brand = styled(Text)`
-  font-size: 10px;
-  font-weight: 300;
-  color: ${({ theme }) => theme.pallete.grey3};
-`;
-
-export const InfoRight = styled.div`
-  display: flex;
-  padding: 10px 0px;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 5px;
-`;
-
-export const PriceCompare = styled.div`
-  display: flex;
-  gap: 5px;
-`;
-
-export const OriginPrice = styled(Text)<TextProps<'del'>>`
-  margin-bottom: 10px;
-  font-weight: 500;
-`;
-
-export const DiscountedPrice = styled(Text)<TextProps<'span'>>``;
 
 export const SelectWrap = styled.section`
   width: 100%;

--- a/src/components/server/ProductDetail/OrderForm/index.tsx
+++ b/src/components/server/ProductDetail/OrderForm/index.tsx
@@ -192,9 +192,13 @@ export function Purchase() {
     },
   };
   const decideProps = {
-    finalPrice,
-    isFormFilled,
-    postOrder,
+    state: {
+      finalPrice,
+      isFormFilled,
+    },
+    func: {
+      postOrder,
+    },
   };
 
   const orderResponseModal = !!message && (

--- a/src/components/server/ProductDetail/OrderForm/index.tsx
+++ b/src/components/server/ProductDetail/OrderForm/index.tsx
@@ -4,9 +4,8 @@ import { ChangeEvent, MouseEvent, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 
-import { HeaderType } from '@/apis/api';
+import { getData, HeaderType } from '@/apis/api';
 import * as API from '@/apis/mainProducts';
-import { Text } from '@/components/common';
 import * as S from '@/components/server/ProductDetail/OrderForm/index.style';
 import { useAddressApi } from '@/hooks/useAddressApi';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
@@ -14,6 +13,7 @@ import { useMutationPost } from '@/hooks/useMutationPost';
 import { modalStore } from '@/recoils/modal/modal';
 import { stopEventDelivery } from '@/utils/utils';
 
+import { Decide } from './Decide/Decide';
 import { Info } from './Info';
 import { DefaultOptionsState, Option, OptionType } from './Option';
 
@@ -53,8 +53,9 @@ export function Purchase() {
   const detailPath = `${process.env.PRODUCT}/${productID}`;
   // const recommendPath = `${process.env.MAIN_PRODUCTS}/${productID}/recommendations`;
   // 서버 구현중
-  const { data } = useQuery<API.ProductDetail, AxiosError>(['getInfos'], () =>
-    getInfos(detailPath),
+  const { data } = useQuery<API.ProductDetail, AxiosError>(
+    ['getInfos'],
+    getData<API.ProductDetail>(detailPath),
   );
 
   const { value } = useLocalStorage('loginState');
@@ -122,6 +123,10 @@ export function Purchase() {
     closeModal();
   };
 
+  const onClickPurChaseWrap = (e: MouseEvent) => {
+    e.stopPropagation();
+  };
+
   const closeModal = () => {
     setIsClicked(!isClicked);
     setIsDisplay(false);
@@ -178,7 +183,7 @@ export function Purchase() {
       keyboardSwitches,
       keyboardSwitch,
       amount,
-      address,
+      address1,
       isDisplay,
       errMessage,
     },
@@ -204,26 +209,11 @@ export function Purchase() {
 
   return (
     <S.Dimmed isClicked={isClicked} onClick={onClickDimmed}>
-      <S.PurchaseWrap
-        onClick={e => {
-          stopEventDelivery(e);
-          setIsDisplay(false);
-        }}
-        isClicked={isClicked}
-      >
+      <S.PurchaseWrap onClick={onClickPurChaseWrap} isClicked={isClicked}>
         {orderResponseModal}
         <Info info={infoProps} />
         <Option option={optionProps} />
-        <S.PriceAndButton>
-          <S.DiscountedPrice>{`총 ${finalPrice} 원`}</S.DiscountedPrice>
-          <S.PurchaseButton
-            disabled={!isFormFilled}
-            isFormFilled={isFormFilled}
-            onClick={postOrder}
-          >
-            <Text>구매</Text>
-          </S.PurchaseButton>
-        </S.PriceAndButton>
+        <Decide decide={decideProps} />
       </S.PurchaseWrap>
     </S.Dimmed>
   );

--- a/src/components/server/ProductDetail/OrderForm/index.tsx
+++ b/src/components/server/ProductDetail/OrderForm/index.tsx
@@ -15,6 +15,8 @@ import { useMutationPost } from '@/hooks/useMutationPost';
 import { modalStore } from '@/recoils/modal/modal';
 import { stopEventDelivery } from '@/utils/utils';
 
+import { Info } from './Info';
+
 const getInfos = async (path: string) => {
   const result = await axios.get<API.ProductDetail>(path);
   return result.data;
@@ -22,17 +24,19 @@ const getInfos = async (path: string) => {
 
 type DefaultOptionsState = {
   [key: string]: string | number;
-  switch: string;
+  keyboardSwitch: string;
   amount: number;
 };
 
-const defaultOptions: DefaultOptionsState = { switch: '', amount: 1 };
+const defaultOptions: DefaultOptionsState = {
+  keyboardSwitch: '',
+  amount: 1,
+};
 
 type OrderResponseState = {
   id: number;
   message: string;
 };
-
 const defaultOrderResponse: OrderResponseState = {
   id: 0,
   message: '',
@@ -43,8 +47,8 @@ const getValue = (e: ChangeEvent<HTMLInputElement>) => e.target.value;
 const URL = `${process.env.ORDER_PRODUCTS}`;
 
 export function Purchase() {
-  const [isDisplay, setIsDisplay] = useState(false);
-  const [isClicked, setIsClicked] = useRecoilState(modalStore);
+  const [isDisplay, setIsDisplay] = useState(false); // 모달
+  const [isClicked, setIsClicked] = useRecoilState(modalStore); // 모달
   const [orderResponse, setOrderResponse] = useState(defaultOrderResponse);
   const [options, setOptions] = useState(defaultOptions);
   const location = useLocation();
@@ -85,12 +89,26 @@ export function Purchase() {
     throw new Error('데이터 없음');
   }
 
-  const { product, discountInfoResponse } = data;
-  const { id: productId, price: productTotalPrice } = product;
-  const { amount } = options;
-  const { salePrice } = discountInfoResponse;
+  const { product, discountInfoResponse, vendor } = data;
+  const { id: productId, price: productTotalPrice, imageUrl, title } = product;
+  const { keyboardSwitch, amount } = options;
+  const { message } = orderResponse;
+  const { name: brandName } = vendor;
+  const { salePrice, discounts } = discountInfoResponse;
   const totalPrice = salePrice * amount;
+  const salePriceWithComma = salePrice.toLocaleString();
+  const finalPrice = (salePrice * amount).toLocaleString();
   const { address1, address2, zipCode } = address;
+  const ADDRESS = '주소';
+
+  const productInfo = {
+    imageUrl,
+    title,
+    brandName,
+    salePriceWithComma,
+    discounts,
+    productTotalPrice,
+  };
 
   const { mutate } = useMutationPost(
     URL,
@@ -114,17 +132,6 @@ export function Purchase() {
     headers,
   );
 
-  const optionLists = data?.keyboardSwitches.map(({ id, name }) => (
-    <S.Option
-      key={id}
-      onClick={() => {
-        setOptions({ ...options, switch: name });
-      }}
-    >
-      {name}
-    </S.Option>
-  ));
-
   const closeModal = (e: MouseEvent) => {
     e.stopPropagation();
     setIsClicked(!isClicked);
@@ -143,20 +150,60 @@ export function Purchase() {
     }
   };
 
-  const isFormFilled =
-    !Object.keys(address).find(key => !address[key]) &&
-    !Object.keys(options).find(key => !options[key]);
-
   const postOrder = () => {
     mutate();
   };
 
   const setAddressErrorMsg = (inputValue: string) =>
     inputValue.length < 5 ? 'wrongAddress' : '';
-
   const errMessage = setAddressErrorMsg(address.address2);
+  const optionLists = data?.keyboardSwitches.map(({ id, name }) => (
+    <S.Option
+      key={id}
+      onClick={() => {
+        setOptions({ ...options, switch: name });
+      }}
+    >
+      {name}
+    </S.Option>
+  ));
 
-  const content = '주소';
+  const optionList = isDisplay && (
+    <S.OptionList isDisplay={isDisplay}>{optionLists}</S.OptionList>
+  );
+  const chooseAmount = keyboardSwitch && (
+    <S.AmountWrap>
+      <S.PlusBtn onClick={increaseAmount}>+</S.PlusBtn>
+      <Text styles={{ fontSize: '15px' }}>{amount}</Text>
+      <S.MinusBtn onClick={decreaseAmount}>-</S.MinusBtn>
+    </S.AmountWrap>
+  );
+
+  const userInfo = amount && keyboardSwitch && (
+    <S.UserInfo>
+      <S.UserInfoTitle>사용자정보</S.UserInfoTitle>
+      <S.UserInfoContent>
+        주소
+        <S.ChangeAddressBtn type="button" onClick={addressControll}>
+          {address.address1 ? '주소변경' : '주소선택'}
+        </S.ChangeAddressBtn>
+      </S.UserInfoContent>
+      <S.Address1>{address.address1}</S.Address1>
+      <S.Address2
+        placeholder="상세주소를 입력해주세요"
+        onChange={onChangeAddress2}
+      />
+      {errMessage && <Caution content={ADDRESS} message={errMessage} />}
+    </S.UserInfo>
+  );
+
+  const orderResponseModal = !!message && (
+    <S.OrderConfirmation>{message}</S.OrderConfirmation>
+  );
+
+  const isFormFilled =
+    !Object.keys(address).find(key => !address[key]) &&
+    !Object.keys(options).find(key => !options[key]);
 
   return (
     <S.Dimmed isClicked={isClicked} onClick={closeModal}>
@@ -167,51 +214,8 @@ export function Purchase() {
         }}
         isClicked={isClicked}
       >
-        {!!orderResponse.message && (
-          <S.OrderConfirmation>{orderResponse.message}</S.OrderConfirmation>
-        )}
-        <S.InfoWrap>
-          <S.ProductImage src={data.product.imageUrl} />
-          <S.ProductDetail>
-            <S.InfoLeft>
-              <S.ProductInfo>
-                <S.Title>{data.product.title}</S.Title>
-                <S.Brand>{data.vendor.name}</S.Brand>
-              </S.ProductInfo>
-            </S.InfoLeft>
-            <S.InfoRight>
-              <S.PriceCompare>
-                {!!data.discountInfoResponse.discounts.length && (
-                  <S.OriginPrice
-                    styles={{ color: 'grey', fontSize: '10px' }}
-                    forwardedAs="del"
-                  >
-                    {data.product.price.toLocaleString()}
-                  </S.OriginPrice>
-                )}
-                <S.DiscountedPrice>
-                  {`${data.discountInfoResponse.salePrice.toLocaleString()} 원`}
-                </S.DiscountedPrice>
-              </S.PriceCompare>
-
-              {!!data.discountInfoResponse.discounts.length && (
-                <S.DiscountRate color="warning">
-                  {data.discountInfoResponse.discounts.length &&
-                    `${
-                      data.discountInfoResponse.discounts.reduce(
-                        (acc, curr) => {
-                          return {
-                            ...acc,
-                            saleRate: String(+acc.saleRate + +curr.saleRate),
-                          };
-                        },
-                      ).saleRate
-                    }%`}
-                </S.DiscountRate>
-              )}
-            </S.InfoRight>
-          </S.ProductDetail>
-        </S.InfoWrap>
+        {orderResponseModal}
+        <Info info={productInfo} />
         <S.OptionZone>
           <S.DetailOptionBtn
             onClick={e => {
@@ -223,42 +227,13 @@ export function Purchase() {
               option
             </Text>
           </S.DetailOptionBtn>
-          <Text typography="Light">{options.switch}</Text>
-          {isDisplay && (
-            <S.OptionList isDisplay={isDisplay}>{optionLists}</S.OptionList>
-          )}
-          {options.switch && (
-            <S.AmountWrap>
-              <S.PlusBtn onClick={increaseAmount}>+</S.PlusBtn>
-              <Text styles={{ fontSize: '15px' }}>{options.amount}</Text>
-              <S.MinusBtn onClick={decreaseAmount}>-</S.MinusBtn>
-            </S.AmountWrap>
-          )}
+          <Text typography="Light">{keyboardSwitch}</Text>
+          {optionList}
+          {chooseAmount}
         </S.OptionZone>
-
-        {options.amount && options.switch && (
-          <S.UserInfo>
-            <S.UserInfoTitle>사용자정보</S.UserInfoTitle>
-            <S.UserInfoContent>
-              주소
-              <S.ChangeAddressBtn type="button" onClick={addressControll}>
-                {address.address1 ? '주소변경' : '주소선택'}
-              </S.ChangeAddressBtn>
-            </S.UserInfoContent>
-            <S.Address1>{address.address1}</S.Address1>
-            <S.Address2
-              placeholder="상세주소를 입력해주세요"
-              onChange={onChangeAddress2}
-            />
-            {errMessage && <Caution content={content} message={errMessage} />}
-          </S.UserInfo>
-        )}
+        {userInfo}
         <S.PriceAndButton>
-          <S.DiscountedPrice>
-            {`총 ${(
-              data.discountInfoResponse.salePrice * options.amount
-            ).toLocaleString()} 원`}
-          </S.DiscountedPrice>
+          <S.DiscountedPrice>{`총 ${finalPrice} 원`}</S.DiscountedPrice>
           <S.PurchaseButton
             disabled={!isFormFilled}
             isFormFilled={isFormFilled}

--- a/src/components/server/ProductDetail/OrderForm/index.tsx
+++ b/src/components/server/ProductDetail/OrderForm/index.tsx
@@ -89,8 +89,14 @@ export function Purchase() {
     throw new Error('데이터 없음');
   }
 
-  const { product, discountInfoResponse, vendor } = data;
-  const { id: productId, price: productTotalPrice, imageUrl, title } = product;
+  const { product, discountInfoResponse, vendor, keyboardSwitches } = data;
+  const {
+    id: productId,
+    price: productTotalPrice,
+    imageUrl,
+    title,
+    quantity,
+  } = product;
   const { keyboardSwitch, amount } = options;
   const { message } = orderResponse;
   const { name: brandName } = vendor;
@@ -101,7 +107,7 @@ export function Purchase() {
   const { address1, address2, zipCode } = address;
   const ADDRESS = '주소';
 
-  const productInfo = {
+  const infoProps = {
     imageUrl,
     title,
     brandName,
@@ -110,6 +116,15 @@ export function Purchase() {
     productTotalPrice,
   };
 
+  const optionProps = {
+    keyboardSwitches,
+    keyboardSwitch,
+    amount,
+    address1,
+    ADDRESS,
+    quantity,
+    options,
+  };
   const { mutate } = useMutationPost(
     URL,
     {
@@ -184,7 +199,7 @@ export function Purchase() {
       <S.UserInfoTitle>사용자정보</S.UserInfoTitle>
       <S.UserInfoContent>
         주소
-        <S.ChangeAddressBtn type="button" onClick={addressControll}>
+        <S.ChangeAddressBtn type="button" onClick={}>
           {address.address1 ? '주소변경' : '주소선택'}
         </S.ChangeAddressBtn>
       </S.UserInfoContent>
@@ -215,7 +230,7 @@ export function Purchase() {
         isClicked={isClicked}
       >
         {orderResponseModal}
-        <Info info={productInfo} />
+        <Info info={infoProps} />
         <S.OptionZone>
           <S.DetailOptionBtn
             onClick={e => {

--- a/src/components/server/ProductDetail/OrderForm/index.tsx
+++ b/src/components/server/ProductDetail/OrderForm/index.tsx
@@ -16,16 +16,11 @@ import { modalStore } from '@/recoils/modal/modal';
 import { stopEventDelivery } from '@/utils/utils';
 
 import { Info } from './Info';
+import { DefaultOptionsState, Option } from './option';
 
 const getInfos = async (path: string) => {
   const result = await axios.get<API.ProductDetail>(path);
   return result.data;
-};
-
-type DefaultOptionsState = {
-  [key: string]: string | number;
-  keyboardSwitch: string;
-  amount: number;
 };
 
 const defaultOptions: DefaultOptionsState = {
@@ -62,11 +57,6 @@ export function Purchase() {
   const { data } = useQuery<API.ProductDetail, AxiosError>(['getInfos'], () =>
     getInfos(detailPath),
   );
-
-  const onChangeAddress2 = (e: ChangeEvent<HTMLInputElement>) => {
-    const inputValue = getValue(e);
-    setDetailAddress(inputValue);
-  };
 
   const { value } = useLocalStorage('loginState');
   const { loginToken } = value;
@@ -105,7 +95,6 @@ export function Purchase() {
   const salePriceWithComma = salePrice.toLocaleString();
   const finalPrice = (salePrice * amount).toLocaleString();
   const { address1, address2, zipCode } = address;
-  const ADDRESS = '주소';
 
   const infoProps = {
     imageUrl,
@@ -116,15 +105,6 @@ export function Purchase() {
     productTotalPrice,
   };
 
-  const optionProps = {
-    keyboardSwitches,
-    keyboardSwitch,
-    amount,
-    address1,
-    ADDRESS,
-    quantity,
-    options,
-  };
   const { mutate } = useMutationPost(
     URL,
     {
@@ -153,64 +133,22 @@ export function Purchase() {
     setIsDisplay(false);
   };
 
-  const increaseAmount = () => {
-    if (options.amount < data?.product.quantity) {
-      setOptions({ ...options, amount: options.amount + 1 });
-    }
-  };
-
-  const decreaseAmount = () => {
-    if (options.amount > 1) {
-      setOptions({ ...options, amount: options.amount - 1 });
-    }
-  };
-
   const postOrder = () => {
     mutate();
   };
 
-  const setAddressErrorMsg = (inputValue: string) =>
-    inputValue.length < 5 ? 'wrongAddress' : '';
-  const errMessage = setAddressErrorMsg(address.address2);
-  const optionLists = data?.keyboardSwitches.map(({ id, name }) => (
-    <S.Option
-      key={id}
-      onClick={() => {
-        setOptions({ ...options, switch: name });
-      }}
-    >
-      {name}
-    </S.Option>
-  ));
-
-  const optionList = isDisplay && (
-    <S.OptionList isDisplay={isDisplay}>{optionLists}</S.OptionList>
-  );
-  const chooseAmount = keyboardSwitch && (
-    <S.AmountWrap>
-      <S.PlusBtn onClick={increaseAmount}>+</S.PlusBtn>
-      <Text styles={{ fontSize: '15px' }}>{amount}</Text>
-      <S.MinusBtn onClick={decreaseAmount}>-</S.MinusBtn>
-    </S.AmountWrap>
-  );
-
-  const userInfo = amount && keyboardSwitch && (
-    <S.UserInfo>
-      <S.UserInfoTitle>사용자정보</S.UserInfoTitle>
-      <S.UserInfoContent>
-        주소
-        <S.ChangeAddressBtn type="button" onClick={}>
-          {address.address1 ? '주소변경' : '주소선택'}
-        </S.ChangeAddressBtn>
-      </S.UserInfoContent>
-      <S.Address1>{address.address1}</S.Address1>
-      <S.Address2
-        placeholder="상세주소를 입력해주세요"
-        onChange={onChangeAddress2}
-      />
-      {errMessage && <Caution content={ADDRESS} message={errMessage} />}
-    </S.UserInfo>
-  );
+  const optionProps = {
+    keyboardSwitches,
+    keyboardSwitch,
+    amount,
+    quantity,
+    options,
+    setOptions,
+    address,
+    address2,
+    addressControll,
+    setDetailAddress,
+  };
 
   const orderResponseModal = !!message && (
     <S.OrderConfirmation>{message}</S.OrderConfirmation>
@@ -231,22 +169,7 @@ export function Purchase() {
       >
         {orderResponseModal}
         <Info info={infoProps} />
-        <S.OptionZone>
-          <S.DetailOptionBtn
-            onClick={e => {
-              setIsDisplay(true);
-              e.stopPropagation();
-            }}
-          >
-            <Text typography="Light" styles={{ fontSize: '9px' }}>
-              option
-            </Text>
-          </S.DetailOptionBtn>
-          <Text typography="Light">{keyboardSwitch}</Text>
-          {optionList}
-          {chooseAmount}
-        </S.OptionZone>
-        {userInfo}
+        <Option option={optionProps} />
         <S.PriceAndButton>
           <S.DiscountedPrice>{`총 ${finalPrice} 원`}</S.DiscountedPrice>
           <S.PurchaseButton

--- a/src/components/server/ProductDetail/OrderForm/index.tsx
+++ b/src/components/server/ProductDetail/OrderForm/index.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import axios, { AxiosError } from 'axios';
+import { AxiosError } from 'axios';
 import { ChangeEvent, MouseEvent, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
@@ -11,16 +11,10 @@ import { useAddressApi } from '@/hooks/useAddressApi';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useMutationPost } from '@/hooks/useMutationPost';
 import { modalStore } from '@/recoils/modal/modal';
-import { stopEventDelivery } from '@/utils/utils';
 
 import { Decide } from './Decide/Decide';
 import { Info } from './Info';
 import { DefaultOptionsState, Option, OptionType } from './Option';
-
-const getInfos = async (path: string) => {
-  const result = await axios.get<API.ProductDetail>(path);
-  return result.data;
-};
 
 const defaultOptions: DefaultOptionsState = {
   keyboardSwitch: '',

--- a/src/components/server/ProductDetail/OrderForm/option/index.tsx
+++ b/src/components/server/ProductDetail/OrderForm/option/index.tsx
@@ -4,22 +4,28 @@ import styled from 'styled-components';
 import { Text } from '@/components/common';
 import { Caution } from '@/components/common/Caution';
 import { TextProps } from '@/components/common/Text/types';
-import { DefaultAddressState } from '@/hooks/useAddressApi';
 
-type OptionType = {
-  amount: number;
-  keyboardSwitch: string;
-  keyboardSwitches: {
-    id: number;
-    name: string;
-  }[];
-  quantity: number;
-  options: DefaultOptionsState;
-  setOptions: Dispatch<DefaultOptionsState>;
-  address: DefaultAddressState;
-  address2: string;
-  addressControll: () => void;
-  setDetailAddress: (value: string) => void;
+export type OptionType = {
+  state: {
+    amount: number;
+    keyboardSwitch: string;
+    keyboardSwitches: {
+      id: number;
+      name: string;
+    }[];
+    address1: string;
+    isDisplay: boolean;
+    errMessage: 'wrongAddress' | '';
+  };
+  func: {
+    addressControll: () => void;
+    setDetailAddress: (value: string) => void;
+    setIsDisplay: Dispatch<boolean>;
+    onClickPlusBtn: () => void;
+    onClickMinusBtn: () => void;
+    onChangeAddress2: (e: ChangeEvent<HTMLInputElement>) => void;
+    getOptionHandler: (name: string) => () => void;
+  };
 };
 
 type OptionProps = {
@@ -33,61 +39,39 @@ export type DefaultOptionsState = {
 };
 
 export function Option({ option }: OptionProps) {
+  const { state, func } = option;
   const {
     amount,
     keyboardSwitch,
     keyboardSwitches,
-    quantity,
-    options,
-    setOptions,
-    address,
-    address2,
+    address1,
+    isDisplay,
+    errMessage,
+  } = state;
+  const {
     addressControll,
-    setDetailAddress,
-  } = option;
-  const [isDisplay, setIsDisplay] = useState(false); // 모달
+    setIsDisplay,
+    onClickMinusBtn,
+    onClickPlusBtn,
+    onChangeAddress2,
+    getOptionHandler,
+  } = func;
   const ADDRESS = '주소';
 
-  const setAddressErrorMsg = (inputValue: string) =>
-    inputValue.length < 5 ? 'wrongAddress' : '';
-  const errMessage = setAddressErrorMsg(address2);
-
   const optionLists = keyboardSwitches.map(({ id, name }) => (
-    <SwitchOption
-      key={id}
-      onClick={() => {
-        setOptions({ ...options, keyboardSwitch: name });
-      }}
-    >
+    <SwitchOption key={id} onClick={getOptionHandler(name)}>
       {name}
     </SwitchOption>
   ));
-
-  const increaseAmount = () => {
-    if (amount < quantity) {
-      setOptions({ ...options, amount: amount + 1 });
-    }
-  };
-
-  const decreaseAmount = () => {
-    if (amount > 1) {
-      setOptions({ ...options, amount: amount - 1 });
-    }
-  };
-
-  const onChangeAddress2 = (e: ChangeEvent<HTMLInputElement>) => {
-    const inputValue = getValue(e);
-    setDetailAddress(inputValue);
-  };
 
   const optionList = isDisplay && (
     <OptionList isDisplay={isDisplay}>{optionLists}</OptionList>
   );
   const chooseAmount = keyboardSwitch && (
     <AmountWrap>
-      <PlusBtn onClick={increaseAmount}>+</PlusBtn>
+      <PlusBtn onClick={onClickPlusBtn}>+</PlusBtn>
       <Text styles={{ fontSize: '15px' }}>{amount}</Text>
-      <MinusBtn onClick={decreaseAmount}>-</MinusBtn>
+      <MinusBtn onClick={onClickMinusBtn}>-</MinusBtn>
     </AmountWrap>
   );
 
@@ -97,10 +81,10 @@ export function Option({ option }: OptionProps) {
       <UserInfoContent>
         주소
         <ChangeAddressBtn type="button" onClick={addressControll}>
-          {address.address1 ? '주소변경' : '주소선택'}
+          {address1 ? '주소변경' : '주소선택'}
         </ChangeAddressBtn>
       </UserInfoContent>
-      <Address1>{address.address1}</Address1>
+      <Address1>{address1}</Address1>
       <Address2
         placeholder="상세주소를 입력해주세요"
         onChange={onChangeAddress2}
@@ -108,8 +92,6 @@ export function Option({ option }: OptionProps) {
       {errMessage && <Caution content={ADDRESS} message={errMessage} />}
     </UserInfo>
   );
-
-  const getValue = (e: ChangeEvent<HTMLInputElement>) => e.target.value;
 
   return (
     <>

--- a/src/components/server/ProductDetail/OrderForm/option/index.tsx
+++ b/src/components/server/ProductDetail/OrderForm/option/index.tsx
@@ -1,0 +1,195 @@
+import { ChangeEvent } from 'react';
+import styled from 'styled-components';
+
+import { Text } from '@/components/common';
+import { Caution } from '@/components/common/Caution';
+import { TextProps } from '@/components/common/Text/types';
+import { useAddressApi } from '@/hooks/useAddressApi';
+
+export function Option({ option }) {
+  const { amount, keyboardSwitch, keyboardSwitches, ADDRESS, quantity } =
+    option;
+  const [options, setOptions] = useState(defaultOptions);
+  const { address, reset, addressControll, setDetailAddress } = useAddressApi();
+  const [isDisplay, setIsDisplay] = useState(false); // 모달
+
+  const optionLists = data?.keyboardSwitches.map(({ id, name }) => (
+    <Option
+      key={id}
+      onClick={() => {
+        setOptions({ ...options, switch: name });
+      }}
+    >
+      {name}
+    </Option>
+  ));
+
+  const optionList = isDisplay && (
+    <OptionList isDisplay={isDisplay}>{optionLists}</OptionList>
+  );
+  const chooseAmount = keyboardSwitch && (
+    <AmountWrap>
+      <PlusBtn onClick={increaseAmount}>+</PlusBtn>
+      <Text styles={{ fontSize: '15px' }}>{amount}</Text>
+      <MinusBtn onClick={decreaseAmount}>-</MinusBtn>
+    </AmountWrap>
+  );
+
+  const userInfo = amount && keyboardSwitch && (
+    <UserInfo>
+      <UserInfoTitle>사용자정보</UserInfoTitle>
+      <UserInfoContent>
+        주소
+        <ChangeAddressBtn type="button" onClick={addressControll}>
+          {address.address1 ? '주소변경' : '주소선택'}
+        </ChangeAddressBtn>
+      </UserInfoContent>
+      <Address1>{address.address1}</Address1>
+      <Address2
+        placeholder="상세주소를 입력해주세요"
+        onChange={onChangeAddress2}
+      />
+      {errMessage && <Caution content={ADDRESS} message={errMessage} />}
+    </UserInfo>
+  );
+
+  const increaseAmount = () => {
+    if (options.amount < data?.product.quantity) {
+      setOptions({ ...options, amount: options.amount + 1 });
+    }
+  };
+
+  const decreaseAmount = () => {
+    if (options.amount > 1) {
+      setOptions({ ...options, amount: options.amount - 1 });
+    }
+  };
+
+  const onChangeAddress2 = (e: ChangeEvent<HTMLInputElement>) => {
+    const inputValue = getValue(e);
+    setDetailAddress(inputValue);
+  };
+  return (
+    <>
+      <OptionZone>
+        <DetailOptionBtn
+          onClick={e => {
+            setIsDisplay(true);
+            e.stopPropagation();
+          }}
+        >
+          <Text typography="Light" styles={{ fontSize: '9px' }}>
+            option
+          </Text>
+        </DetailOptionBtn>
+        <Text typography="Light">{keyboardSwitch}</Text>
+        {optionList}
+        {chooseAmount}
+      </OptionZone>
+      {userInfo}
+    </>
+  );
+}
+const OptionZone = styled.section`
+  display: flex;
+  box-sizing: border-box;
+  width: 100%;
+  gap: 10px;
+  padding: 15px;
+  flex-direction: column;
+  background-color: #fef8d8;
+  border-radius: 10px;
+`;
+
+const DetailOptionBtn = styled.button`
+  display: flex;
+  align-items: center;
+  padding: 5px;
+  width: fit-content;
+  border-radius: 10px;
+
+  border: none;
+  background-color: ${({ theme }) => theme.pallete.secondary};
+  &:hover {
+    transform: scale(0.9);
+  }
+  transition: 0.2s;
+`;
+
+const OptionList = styled.ul<{ isDisplay: boolean }>`
+  position: absolute;
+  left: 20%;
+  display: ${({ isDisplay }) => (isDisplay ? 'flex' : 'none')};
+  border: 1px solid black;
+  width: fit-content;
+  border-radius: 10px;
+`;
+
+const Option = styled.li`
+  padding: 5px 10px;
+`;
+
+const AmountWrap = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`;
+
+const AmountBtn = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+`;
+const MinusBtn = styled(AmountBtn)``;
+
+const PlusBtn = styled(AmountBtn)``;
+
+const UserInfo = styled.div`
+  width: 100%;
+  background-color: #dde9d1;
+  border-radius: 10px;
+  padding: 15px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const UserInfoTitle = styled(Text)<TextProps<'span'>>`
+  font-size: 15px;
+`;
+const UserInfoContent = styled(Text)`
+  color: ${({ theme }) => theme.pallete.grey3};
+  font-size: 10px;
+`;
+const ChangeAddressBtn = styled.button`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  margin-left: 15px;
+  border: none;
+  background: none;
+  color: ${({ theme }) => theme.pallete.grey4};
+`;
+const Address1 = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 22px; // Address2랑 똑같이 20px로 했는데 크기가 작음. input 여백 설정이 남아있는듯
+  border: 1px solid ${({ theme }) => theme.pallete.grey3};
+  border-radius: 3px;
+  font-size: 10px;
+  padding-left: 5px;
+  background: ${({ theme }) => theme.pallete.white};
+`;
+const Address2 = styled.input`
+  padding: 0;
+  height: 20px;
+  border: 1px solid ${({ theme }) => theme.pallete.grey3};
+  border-radius: 3px;
+  font-size: 10px;
+  padding-left: 5px;
+`;

--- a/src/components/server/ProductDetail/OrderForm/option/index.tsx
+++ b/src/components/server/ProductDetail/OrderForm/option/index.tsx
@@ -1,28 +1,84 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent, Dispatch, useState } from 'react';
 import styled from 'styled-components';
 
 import { Text } from '@/components/common';
 import { Caution } from '@/components/common/Caution';
 import { TextProps } from '@/components/common/Text/types';
-import { useAddressApi } from '@/hooks/useAddressApi';
+import { DefaultAddressState } from '@/hooks/useAddressApi';
 
-export function Option({ option }) {
-  const { amount, keyboardSwitch, keyboardSwitches, ADDRESS, quantity } =
-    option;
-  const [options, setOptions] = useState(defaultOptions);
-  const { address, reset, addressControll, setDetailAddress } = useAddressApi();
+type OptionType = {
+  amount: number;
+  keyboardSwitch: string;
+  keyboardSwitches: {
+    id: number;
+    name: string;
+  }[];
+  quantity: number;
+  options: DefaultOptionsState;
+  setOptions: Dispatch<DefaultOptionsState>;
+  address: DefaultAddressState;
+  address2: string;
+  addressControll: () => void;
+  setDetailAddress: (value: string) => void;
+};
+
+type OptionProps = {
+  option: OptionType;
+};
+
+export type DefaultOptionsState = {
+  [key: string]: string | number;
+  keyboardSwitch: string;
+  amount: number;
+};
+
+export function Option({ option }: OptionProps) {
+  const {
+    amount,
+    keyboardSwitch,
+    keyboardSwitches,
+    quantity,
+    options,
+    setOptions,
+    address,
+    address2,
+    addressControll,
+    setDetailAddress,
+  } = option;
   const [isDisplay, setIsDisplay] = useState(false); // 모달
+  const ADDRESS = '주소';
 
-  const optionLists = data?.keyboardSwitches.map(({ id, name }) => (
-    <Option
+  const setAddressErrorMsg = (inputValue: string) =>
+    inputValue.length < 5 ? 'wrongAddress' : '';
+  const errMessage = setAddressErrorMsg(address2);
+
+  const optionLists = keyboardSwitches.map(({ id, name }) => (
+    <SwitchOption
       key={id}
       onClick={() => {
-        setOptions({ ...options, switch: name });
+        setOptions({ ...options, keyboardSwitch: name });
       }}
     >
       {name}
-    </Option>
+    </SwitchOption>
   ));
+
+  const increaseAmount = () => {
+    if (amount < quantity) {
+      setOptions({ ...options, amount: amount + 1 });
+    }
+  };
+
+  const decreaseAmount = () => {
+    if (amount > 1) {
+      setOptions({ ...options, amount: amount - 1 });
+    }
+  };
+
+  const onChangeAddress2 = (e: ChangeEvent<HTMLInputElement>) => {
+    const inputValue = getValue(e);
+    setDetailAddress(inputValue);
+  };
 
   const optionList = isDisplay && (
     <OptionList isDisplay={isDisplay}>{optionLists}</OptionList>
@@ -53,22 +109,8 @@ export function Option({ option }) {
     </UserInfo>
   );
 
-  const increaseAmount = () => {
-    if (options.amount < data?.product.quantity) {
-      setOptions({ ...options, amount: options.amount + 1 });
-    }
-  };
+  const getValue = (e: ChangeEvent<HTMLInputElement>) => e.target.value;
 
-  const decreaseAmount = () => {
-    if (options.amount > 1) {
-      setOptions({ ...options, amount: options.amount - 1 });
-    }
-  };
-
-  const onChangeAddress2 = (e: ChangeEvent<HTMLInputElement>) => {
-    const inputValue = getValue(e);
-    setDetailAddress(inputValue);
-  };
   return (
     <>
       <OptionZone>
@@ -125,7 +167,7 @@ const OptionList = styled.ul<{ isDisplay: boolean }>`
   border-radius: 10px;
 `;
 
-const Option = styled.li`
+const SwitchOption = styled.li`
   padding: 5px 10px;
 `;
 

--- a/src/hooks/useAddressApi.tsx
+++ b/src/hooks/useAddressApi.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 
 export type DefaultAddressState = {
+  [key: string]: string | number;
   address1: string;
   address2: string;
   zipCode: string;

--- a/src/hooks/useMutationPost.ts
+++ b/src/hooks/useMutationPost.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { useMutation } from '@tanstack/react-query';
 
-import { postData } from '@/apis/api';
+import { HeaderType, postData } from '@/apis/api';
 
 // TODO: Funtion타입 활용해도 되는가?
 export const useMutationPost = <
@@ -11,10 +11,11 @@ export const useMutationPost = <
 >(
   URL: string,
   info: RequestBody,
+  header?: HeaderType,
   onSuccessCallback?: onSuccessCallBackFn,
   onErrorCallback?: onErrorCallbackFn,
 ) => {
-  return useMutation(() => postData(URL, info), {
+  return useMutation(() => postData(URL, info, header), {
     onSuccess: data => {
       if (onSuccessCallback) {
         onSuccessCallback(data);

--- a/src/templates/SigninForm/index.tsx
+++ b/src/templates/SigninForm/index.tsx
@@ -1,0 +1,304 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import {
+  useState,
+  Dispatch,
+  ChangeEvent,
+  ElementType,
+  useReducer,
+} from 'react';
+import styled from 'styled-components';
+
+import { Button, Text } from '@/components/common';
+import { Caution } from '@/components/common/Caution';
+import {
+  CautionMessage,
+  CautionContent,
+} from '@/components/common/Caution/types';
+import { UserInput, UserInputProps } from '@/components/common/Input/User';
+import { Logo } from '@/components/common/Logo';
+import { useAddressApi, DefaultAddressState } from '@/hooks/useAddressApi';
+import { useMutationPost } from '@/hooks/useMutationPost';
+import {
+  idValid,
+  nameValid,
+  signInPasswordValid,
+  confirmPasswordValid,
+} from '@/service/login';
+import {
+  getEmailAction,
+  getNameAction,
+  getPasswordAction,
+  getPasswordConfirmAction,
+  getSignInDispatch,
+} from '@/templates/SigninForm/Actions';
+import {
+  DEFAULT_SIGNIN_STATE,
+  signInReducer,
+} from '@/templates/SigninForm/Reducer';
+
+const onChangeInput =
+  (setterFunc: Dispatch<string>) => (e: ChangeEvent<HTMLInputElement>) => {
+    const {
+      target: { value },
+    } = e;
+
+    setterFunc(value);
+  };
+
+const ID = '아이디';
+const PASSWORD = '비밀번호';
+const URL = `${process.env.SIGN_IN}`;
+
+type SigninResponse = {
+  message: string;
+  error: unknown;
+};
+
+const getSignInForm = (
+  address: DefaultAddressState,
+  signInState: typeof DEFAULT_SIGNIN_STATE,
+) => ({
+  address: { ...address, fulladdress: address.address1 + address.address2 },
+  ...signInState,
+});
+
+type SignInProps = {
+  messageDispatch: Dispatch<string>;
+  modalDisplayDispatch: Dispatch<boolean>;
+  NeedSignInDispatch: () => void;
+};
+
+export function SignInForm({
+  messageDispatch,
+  modalDisplayDispatch,
+  NeedSignInDispatch,
+}: SignInProps) {
+  const {
+    addressControll,
+    address,
+    setDetailAddress,
+    reset: resetAddress,
+  } = useAddressApi();
+  const [signInState, signInDispatch] = useReducer(
+    signInReducer,
+    DEFAULT_SIGNIN_STATE,
+  );
+
+  const { email, password, passwordConfirm, name } = signInState;
+
+  const signInData = getSignInForm(address, signInState);
+  const onSignInFail = (
+    error: AxiosError<SigninResponse, typeof signInData>,
+  ) => {
+    modalDisplayDispatch(true);
+    const res = error.response!;
+    messageDispatch(res.data.message);
+  };
+  const onSignInSuccess = (res: AxiosResponse) => {
+    const { message } = res.data;
+    signInDispatch({ type: 'reset' });
+    resetAddress();
+    messageDispatch(message);
+    modalDisplayDispatch(true);
+    NeedSignInDispatch();
+  };
+  
+  const { mutate } = useMutationPost(
+    URL,
+    signInData,
+    onSignInSuccess,
+    onSignInFail,
+  );
+
+  const eMailDispatch = getSignInDispatch(signInDispatch, getEmailAction);
+  const passwordDispatch = getSignInDispatch(signInDispatch, getPasswordAction);
+  const passwordConfirmDispatch = getSignInDispatch(
+    signInDispatch,
+    getPasswordConfirmAction,
+  );
+  const nameDispatch = getSignInDispatch(signInDispatch, getNameAction);
+
+  const idErrorMessages = idValid(email);
+  const passwordErrorMessages = signInPasswordValid(password);
+  const nameErrorMessges = nameValid(name);
+  const confirmPasswordErrorMessages = confirmPasswordValid({
+    first: password,
+    second: passwordConfirm,
+  });
+
+  const onChangeID = onChangeInput(eMailDispatch);
+  const onChangePassword = onChangeInput(passwordDispatch);
+  const onChangeConfirmPassword = onChangeInput(passwordConfirmDispatch);
+  const onChangeName = onChangeInput(nameDispatch);
+  const onChageAddressDetail = onChangeInput(setDetailAddress);
+  const onClickSignIn = () => {
+    NeedSignInDispatch();
+    mutate();
+  };
+
+  const signInKeys = Object.keys(signInState) as Array<
+    keyof typeof signInState
+  >;
+  const addressKeys = Object.keys(address) as Array<keyof typeof address>;
+  const isSignInFilled = !!signInKeys.find(key => !signInState[key]);
+  const isAddressFilled = !!addressKeys.find(key => !address[key]);
+  // TODO: hasWronInput 리팩토링 가능 위와 묶어서도 가능할까? 고민
+  const hasWrongInput =
+    !!idErrorMessages.find(value => value) ||
+    !!confirmPasswordErrorMessages.find(value => value) ||
+    !!passwordErrorMessages.find(value => value) ||
+    !!nameErrorMessges.find(value => value);
+
+  return (
+    <SignInLayout>
+      <Logo size="small" />
+      <EmailWrap>
+        <SignInInput
+          inputProps={{
+            size: 'medium',
+            iconSrc: 'PERSON',
+            placeholder: ID,
+            onChange: onChangeID,
+            value: email,
+          }}
+          cautionContent={ID}
+          inputErrorMessages={idErrorMessages}
+        />
+        <Button size="small">
+          <Text>중복 확인</Text>
+        </Button>
+      </EmailWrap>
+      <PasswordsLayout>
+        <PasswordWrap>
+          <SignInInput
+            inputProps={{
+              size: 'medium',
+              placeholder: '비밀번호',
+              onChange: onChangePassword,
+              iconSrc: 'LOCK',
+              type: 'password',
+              value: password,
+            }}
+            cautionContent={PASSWORD}
+            inputErrorMessages={passwordErrorMessages}
+          />
+        </PasswordWrap>
+        <PasswordWrap>
+          <SignInInput
+            inputProps={{
+              size: 'medium',
+              placeholder: '비밀번호 재입력',
+              onChange: onChangeConfirmPassword,
+              type: 'password',
+              value: passwordConfirm,
+            }}
+            cautionContent={PASSWORD}
+            inputErrorMessages={confirmPasswordErrorMessages}
+          />
+        </PasswordWrap>
+      </PasswordsLayout>
+      <SignInInput
+        inputProps={{
+          size: 'small',
+          placeholder: '이름',
+          onChange: onChangeName,
+          value: name,
+        }}
+        inputErrorMessages={nameErrorMessges}
+      />
+      <UserInput
+        size="large"
+        placeholder="주소"
+        onClick={addressControll}
+        value={address.address1}
+        style={{ caretColor: 'transparent' }}
+      />
+      <UserInput
+        size="large"
+        placeholder="상세주소"
+        onChange={onChageAddressDetail}
+        value={address.address2}
+      />
+      <UserInput
+        size="small"
+        placeholder="우편번호"
+        value={address.zipCode}
+        disabled
+      />
+      <BtnLayout>
+        <Button
+          onClick={onClickSignIn}
+          disabled={isSignInFilled || isAddressFilled || hasWrongInput}
+        >
+          <Text>회원 가입 완료</Text>
+        </Button>
+        <Button onClick={NeedSignInDispatch}>
+          <Text>로그인 페이지 이동</Text>
+        </Button>
+      </BtnLayout>
+    </SignInLayout>
+  );
+}
+
+function SignInInput<incomeElements extends ElementType = 'input'>({
+  inputProps,
+  cautionContent,
+  inputErrorMessages,
+}: {
+  inputProps: UserInputProps<incomeElements>;
+  cautionContent?: CautionContent;
+  inputErrorMessages: (CautionMessage | false)[];
+}) {
+  const [isInputBlur, setIsInputBlur] = useState(false);
+  const onFocusInput = () => {
+    setIsInputBlur(false);
+  };
+
+  const onBlurInput = () => {
+    setIsInputBlur(true);
+  };
+
+  const inputCaution = inputErrorMessages.map(
+    inputError =>
+      isInputBlur &&
+      inputError && <Caution content={cautionContent} message={inputError} />,
+  );
+
+  return (
+    <SignInInputLayout>
+      <UserInput {...inputProps} onFocus={onFocusInput} onBlur={onBlurInput} />
+      {inputCaution}
+    </SignInInputLayout>
+  );
+}
+
+const SignInLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 20px;
+`;
+const SignInInputLayout = styled(SignInLayout)`
+  align-items: flex-end;
+  gap: 5px;
+`;
+const PasswordsLayout = styled.div`
+  width: 100%;
+  display: flex;
+  gap: 10px;
+`;
+
+const PasswordWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+`;
+const EmailWrap = styled.div`
+  display: flex;
+  gap: 15px;
+`;
+
+const BtnLayout = styled(PasswordsLayout)`
+  margin-top: 40px;
+  justify-content: center;
+`;


### PR DESCRIPTION
## PR 타입 (복수 선택 가능)
- [ ] 구현 사항
- [ ] 버그 수정
- [ ] 환경 설정
- [x] 리팩토링
- [ ] 기타

## 주요 작업
* purchase 컴포넌트 뷰 로직 분리

## 구현 계획
* purchase 컴포넌트 쪼개기
* 변수 체이닝 지우기
* jsx에서 로직 분리
* ui만 담당하는 컴포넌트로 분리


## 코드 리뷰어 에게
* 분리된 컴포넌트가 ui 관련 내용만 담당하게 분리했습니다
* 각 컴포넌트 props를 객체로 넘겨줬는데, 이 props 네이밍을 컴포넌트의 네이밍 그대로 사용했습니다. 좀 더 좋은 방안이 있을까요?
* 아직 서비스 로직은 분리하지 않았고, 컨벤션이 적용된 부분이 어색할 수 있습니다.  혹시나 문제점 발생하시면 바로 지적해주세용
* pr 템플릿 만들어놓길 잘했네요 엄청편하네요 ㅋㅋㅋ
