### PR TITLE
Feat/line

### DIFF
--- a/src/components/common/Line/Line.stories.tsx
+++ b/src/components/common/Line/Line.stories.tsx
@@ -1,0 +1,11 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { Line } from './Line';
+
+export default { title: 'View/Line', component: Line } as ComponentMeta<
+  typeof Line
+>;
+
+const Template: ComponentStory<typeof Line> = args => <Line {...args} />;
+
+export const Default = Template.bind({});

--- a/src/components/common/Line/Line.tsx
+++ b/src/components/common/Line/Line.tsx
@@ -1,0 +1,43 @@
+import styled, { CSSObject } from 'styled-components';
+
+import { globalTheme } from '@/styles/globalTheme';
+
+const { pallete } = globalTheme;
+
+type LineProps = {
+  width: `${number}%` | number;
+  height: `${number}%` | number;
+  margin?: string | number;
+  styles?: CSSObject;
+  isColumn: boolean;
+  color: keyof typeof pallete;
+};
+
+const DEFAULT_LINE_PROPS: LineProps = {
+  width: '100%',
+  height: 1,
+  color: 'grey3',
+  isColumn: false,
+};
+
+export function Line(props: Partial<LineProps>) {
+  const lineProps = { ...DEFAULT_LINE_PROPS, ...props };
+  const { isColumn, width, height } = lineProps;
+
+  const lineWidth = isColumn ? height : width;
+  const lineHeight = isColumn ? width : height;
+
+  return <StyledLine {...lineProps} width={lineWidth} height={lineHeight} />;
+}
+
+const StyledLine = styled.span<LineProps>(
+  ({ width, height, styles, margin, color, theme }) => ({
+    display: 'block',
+    margin,
+    width,
+    height,
+    backgroundColor: theme.pallete[color],
+    borderRadius: 9999999,
+    ...styles,
+  }),
+);

--- a/src/components/common/Line/index.ts
+++ b/src/components/common/Line/index.ts
@@ -1,0 +1,1 @@
+export { Line } from './Line';


### PR DESCRIPTION
## PR 타입 (복수 선택 가능)
- [x] 구현 사항
- [ ] 버그 수정
- [ ] 환경 설정
- [ ] 리팩토링
- [ ] 기타

## 기획 사항 (추후 구현 예정)
* 다양한 상황에서 사용 가능한 View 컴포넌트 Line을 구현한다.

## 주요 작업
* 라인 컴포넌트 설계
* 라인 컴포넌트 구현
* 라인 컴포넌트 스토리 작성

## 구현 계획
* 영역을 나눠주는 역할을 하므로 marigin을 지원하여 여백을 스스로 확보 할 수 있으면 좋을것 같다.
(ex. A | B 상황에서 A B 여백을 위해서 이 둘을 마진을 각각 추가하는건 귀찮고 통일 되지 않을 수 있다. 중앙 Line에만 마진을 주면 통일된 값으로 여백 확보 가능하다)
* 가로와 세로를 지원한다.
* width는 % 와 number 둘 다 사용 가능하게 열어 사용성을 올린다.
(20px 과 20은 동일하므로 이는 타입으로 막아 두었다. 제한된 옵션이 편의성을 올리니깐)


## 데모
스토리북 배포시 링크 제공

## 코드 리뷰어 에게
* 원래 isColumn 값을 받아서 transform: rotate(90deg)로 돌렸는데 이럴 경우 다른 영역을 침범 하기 때문에 사용성이 좋지 못하다 판단 했습니다. 다른 영역과 겹치지 않게 하기 위해서 lineWidth와 lineHeight를 만들어서 isColumn의 값을 통해 서로 교체 되는 방식을 채택 했습니다.
* span태그가 inline 속성이라서 그런지 배경색상이 안채워져서 이부분을 display:block을 주는 방식으로 해결 했는데, 너무 날먹으로 해결한거 아닌가? 생각이 들더라구요 혹시 정석적이거나 semantic한 처리 방식 있다면 공유 부탁드릴게요!
* 라인은 사이즈를 제공하지 않았습니다. 독자적으로 사용되기도 하고 길이가 중요한 역할을 띈다고  판단했기 때문입니다.
* 진짜 하나도 안중요한건데 `const { pallete } = theme` 이 코드가 많아서 그냥 globalTheme에 만들어 두고 export할지 고민되네욬 ㅋ