### PR TITLE
[feat]Pagelist common component 구현

### DIFF
--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -9,12 +9,7 @@ type ModalType = {
   store: RecoilState<boolean>;
 };
 
-export function Modal({
-  radius = 'false',
-  width = '',
-  children,
-  store,
-}: ModalType) {
+export function Modal({ radius = 'false', width, children, store }: ModalType) {
   const [isClicked, setIsClicked] = useRecoilState(store);
   const closeModal = () => {
     setIsClicked(!isClicked);
@@ -57,7 +52,7 @@ export const Dimmed = styled.section<{ isClicked: boolean }>`
 const ModalWrap = styled.div<{
   isClicked: boolean;
   radius: boolean | string;
-  width: string;
+  width: string | undefined;
 }>`
   display: ${({ isClicked }) => (isClicked ? 'flex' : 'none')};
   width: ${({ width }) => width};

--- a/src/components/common/PageList/PageList.stories.tsx
+++ b/src/components/common/PageList/PageList.stories.tsx
@@ -1,0 +1,14 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { PageList } from '@/components/common/PageList/pageList';
+
+export default {
+  component: PageList,
+  title: 'View/PageList',
+} as ComponentMeta<typeof PageList>;
+
+const Template: ComponentStory<typeof PageList> = args => (
+  <PageList {...args} />
+);
+
+export const Default = Template.bind({});

--- a/src/components/common/PageList/PageList.stories.tsx
+++ b/src/components/common/PageList/PageList.stories.tsx
@@ -13,21 +13,18 @@ const Template: ComponentStory<typeof PageList> = args => (
 
 export const Default = Template.bind({});
 Default.args = {
-  pageListProps: {
-    state: {
-      start: 1,
-      end: 10,
-      isSkipPage: false,
-    },
-  },
+  end: 10,
+  focus: 2,
 };
 export const Skip = Template.bind({});
 Skip.args = {
-  pageListProps: {
-    state: {
-      start: 1,
-      end: 10,
-      isSkipPage: true,
-    },
-  },
+  end: 10,
+  focus: 3,
+  skipNumber: 6,
+};
+export const Skip2 = Template.bind({});
+Skip2.args = {
+  end: 5,
+  focus: 3,
+  skipNumber: 6,
 };

--- a/src/components/common/PageList/PageList.stories.tsx
+++ b/src/components/common/PageList/PageList.stories.tsx
@@ -5,6 +5,24 @@ import { PageList } from '@/components/common/PageList/pageList';
 export default {
   component: PageList,
   title: 'View/PageList',
+  argTypes: {
+    start: {
+      description: '페이지 시작점, 기본값 1',
+    },
+    end: {
+      description: '페이지 끝점',
+    },
+    focus: {
+      description: '현제 페이지 번호, 다른 버튼 클릭시 그 번호로 상태 변경',
+    },
+    skipNumber: {
+      description:
+        '생략 기준 번호,리스트 항목 갯수. 이 번호보다 end가 커지면 생략 로직 실행, 기본값 end',
+    },
+    setFocus: {
+      description: 'focus 상태를 바꿔줄 dispatch 함수',
+    },
+  },
 } as ComponentMeta<typeof PageList>;
 
 const Template: ComponentStory<typeof PageList> = args => (
@@ -15,16 +33,4 @@ export const Default = Template.bind({});
 Default.args = {
   end: 10,
   focus: 2,
-};
-export const Skip = Template.bind({});
-Skip.args = {
-  end: 10,
-  focus: 3,
-  skipNumber: 6,
-};
-export const Skip2 = Template.bind({});
-Skip2.args = {
-  end: 5,
-  focus: 3,
-  skipNumber: 6,
 };

--- a/src/components/common/PageList/PageList.stories.tsx
+++ b/src/components/common/PageList/PageList.stories.tsx
@@ -12,3 +12,22 @@ const Template: ComponentStory<typeof PageList> = args => (
 );
 
 export const Default = Template.bind({});
+Default.args = {
+  pageListProps: {
+    state: {
+      start: 1,
+      end: 10,
+      isSkipPage: false,
+    },
+  },
+};
+export const Skip = Template.bind({});
+Skip.args = {
+  pageListProps: {
+    state: {
+      start: 1,
+      end: 10,
+      isSkipPage: true,
+    },
+  },
+};

--- a/src/components/common/PageList/PageNumber.tsx
+++ b/src/components/common/PageList/PageNumber.tsx
@@ -15,18 +15,7 @@ export function PageNumber({
   onClickPageNumber,
 }: PageNumberProps) {
   const showingContent = isFocus ? (
-    <Text
-      style={{
-        borderRadius: '999px',
-        backgroundColor: 'black',
-        color: 'white',
-        aspectRatio: '1 / 1',
-        display: 'flex',
-        justifyContent: 'center',
-      }}
-    >
-      {content}
-    </Text>
+    <Text typography="Bold">{content}</Text>
   ) : (
     <Text>{content}</Text>
   );
@@ -38,9 +27,14 @@ export function PageNumber({
         </EventContainer>
       </Container>
     );
-  return <Container>{showingContent}</Container>;
+  return (
+    <Container>
+      <EventContainer>{showingContent}</EventContainer>
+    </Container>
+  );
 }
 const EventContainer = styled.div`
-  width: 100%;
-  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;

--- a/src/components/common/PageList/PageNumber.tsx
+++ b/src/components/common/PageList/PageNumber.tsx
@@ -11,7 +11,7 @@ type PageNumberProps = {
 
 export function PageNumber({
   content,
-  isFocus,
+  isFocus = false,
   onClickPageNumber,
 }: PageNumberProps) {
   const showingContent = isFocus ? (

--- a/src/components/common/PageList/PageNumber.tsx
+++ b/src/components/common/PageList/PageNumber.tsx
@@ -3,12 +3,29 @@ import { Text } from '../Text';
 
 type PageNumberProps = {
   content: number | '...';
+  isFocus?: boolean;
 };
 
-export function PageNumber({ content }: PageNumberProps) {
+export function PageNumber({ content, isFocus }: PageNumberProps) {
+  const showingContent = isFocus ? (
+    <Text
+      style={{
+        borderRadius: '999px',
+        backgroundColor: 'black',
+        color: 'white',
+        aspectRatio: '1 / 1',
+        display: 'flex',
+        justifyContent: 'center',
+      }}
+    >
+      {content}
+    </Text>
+  ) : (
+    <Text>{content}</Text>
+  );
   return (
     <Container justifyContent="center" alignItem="center">
-      <Text>{content}</Text>
+      {showingContent}
     </Container>
   );
 }

--- a/src/components/common/PageList/PageNumber.tsx
+++ b/src/components/common/PageList/PageNumber.tsx
@@ -1,0 +1,14 @@
+import { Container } from '../Layout/Core';
+import { Text } from '../Text';
+
+type PageNumberProps = {
+  content: number | '...';
+};
+
+export function PageNumber({ content }: PageNumberProps) {
+  return (
+    <Container justifyContent="center" alignItem="center">
+      <Text>{content}</Text>
+    </Container>
+  );
+}

--- a/src/components/common/PageList/PageNumber.tsx
+++ b/src/components/common/PageList/PageNumber.tsx
@@ -1,12 +1,19 @@
+import styled from 'styled-components';
+
 import { Container } from '../Layout/Core';
 import { Text } from '../Text';
 
 type PageNumberProps = {
   content: number | '...';
   isFocus?: boolean;
+  onClickPageNumber?: (num: number) => () => void;
 };
 
-export function PageNumber({ content, isFocus }: PageNumberProps) {
+export function PageNumber({
+  content,
+  isFocus,
+  onClickPageNumber,
+}: PageNumberProps) {
   const showingContent = isFocus ? (
     <Text
       style={{
@@ -23,9 +30,17 @@ export function PageNumber({ content, isFocus }: PageNumberProps) {
   ) : (
     <Text>{content}</Text>
   );
-  return (
-    <Container justifyContent="center" alignItem="center">
-      {showingContent}
-    </Container>
-  );
+  if (onClickPageNumber && content !== '...')
+    return (
+      <Container justifyContent="center" alignItem="center">
+        <EventContainer onClick={onClickPageNumber(content)}>
+          {showingContent}
+        </EventContainer>
+      </Container>
+    );
+  return <Container>{showingContent}</Container>;
 }
+const EventContainer = styled.div`
+  width: 100%;
+  height: 100%;
+`;

--- a/src/components/common/PageList/index.tsx
+++ b/src/components/common/PageList/index.tsx
@@ -1,0 +1,1 @@
+export { PageList } from '@/components/common/PageList/pageList';

--- a/src/components/common/PageList/index.tsx
+++ b/src/components/common/PageList/index.tsx
@@ -1,1 +1,2 @@
 export { PageList } from '@/components/common/PageList/pageList';
+export { PageNumber } from '@/components/common/PageList/PageNumber';

--- a/src/components/common/PageList/pageList.tsx
+++ b/src/components/common/PageList/pageList.tsx
@@ -91,8 +91,12 @@ export function PageList({
       </>
     );
 
-  const prevBtn = checkFirstPageList() && <Icon iconSrc="PREV" />;
-  const nextBtn = checkLastPageList() && <Icon iconSrc="NEXT" />;
+  const prevBtn = checkFirstPageList() && (
+    <Icon iconSrc="PREV" width={30} height={30} />
+  );
+  const nextBtn = checkLastPageList() && (
+    <Icon iconSrc="NEXT" width={30} height={30} />
+  );
   return (
     <Container
       backgroundColor="none"

--- a/src/components/common/PageList/pageList.tsx
+++ b/src/components/common/PageList/pageList.tsx
@@ -61,6 +61,9 @@ export function PageList({
     }
   };
 
+  const checkFirstPageList = () => listStart !== 1;
+  const checkLastPageList = () => listEnd !== end;
+
   const pages =
     skipNumber >= end ? (
       pageNumberArr.map((num, idx) =>
@@ -87,16 +90,19 @@ export function PageList({
         <PageNumber content={listEnd} onClickPageNumber={onClickPageNumber} />
       </>
     );
+
+  const prevBtn = checkFirstPageList() && <Icon iconSrc="PREV" />;
+  const nextBtn = checkLastPageList() && <Icon iconSrc="NEXT" />;
   return (
     <Container
       backgroundColor="none"
       justifyContent="center"
       alignItem="center"
-      gap={10}
+      gap={15}
     >
-      <Icon iconSrc="PREV" />
+      {prevBtn}
       {pages}
-      <Icon iconSrc="NEXT" />
+      {nextBtn}
     </Container>
   );
 }

--- a/src/components/common/PageList/pageList.tsx
+++ b/src/components/common/PageList/pageList.tsx
@@ -75,16 +75,16 @@ export function PageList({
     });
     setFocus(newListEnd);
   };
-  const getPageList = (arr: number[]) =>
-    arr.map((num, idx) =>
-      idx + 1 === focus ? (
+  const getPageList = (arr: number[]) => {
+    return arr.map(num =>
+      num === focus ? (
         <PageNumber content={num} isFocus />
       ) : (
         <PageNumber content={num} onClickPageNumber={onClickPageNumber} />
       ),
     );
+  };
   const skipPageList = getPageList(listArr);
-  console.log(focus, listStart, listEnd);
   const pages =
     skipNumber >= end ? (
       getPageList(fullPageNumberArr)

--- a/src/components/common/PageList/pageList.tsx
+++ b/src/components/common/PageList/pageList.tsx
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 
-import { Container } from '@/components/common/Layout/Core';
+import { PageNumber } from './PageNumber';
 
-import { Box } from '../Layout/Box';
-import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { Container } from '../Layout/Core';
 
 type PageListType = {
   state: {
@@ -11,28 +11,52 @@ type PageListType = {
     end: number;
     isSkipPage: boolean;
   };
-  func: {
-    previous: () => void;
-    next: () => void;
-    onClickPage: () => void;
-  };
+  // func: {
+  //   previous: () => void;
+  //   next: () => void;
+  //   onClickPage: () => void;
+  // };
 };
 type PageListProps = {
   pageListProps: PageListType;
 };
-
+const makePageNumberArr = (start: number, end: number) => {
+  const pageNumArr = [];
+  for (let i = start; i <= end; i += 1) {
+    pageNumArr.push(i);
+  }
+  return pageNumArr;
+};
 export function PageList({ pageListProps }: PageListProps) {
   const { state, func } = pageListProps;
   const { start, end, isSkipPage } = state;
-  const { previous, next, onClickPage } = func;
+  // const { previous, next, onClickPage } = func;
+  const mid = Math.floor((start + end) / 2);
+
+  const pageNumberArr = makePageNumberArr(start, end);
+  const pages = !isSkipPage ? (
+    pageNumberArr.map(num => <PageNumber content={num} />)
+  ) : (
+    <>
+      <PageNumber content={start} />
+      <PageNumber content={start + 1} />
+      <PageNumber content="..." />
+      <PageNumber content={mid} />
+      <PageNumber content="..." />
+      <PageNumber content={end - 1} />
+      <PageNumber content={end} />
+    </>
+  );
   return (
-    <Box>
-      <Container>
-        <Text>{start}</Text>
-      </Container>
-      <Container>
-        <Text>{end}</Text>
-      </Container>
-    </Box>
+    <Container
+      backgroundColor="none"
+      justifyContent="center"
+      alignItem="center"
+      gap={10}
+    >
+      <Icon iconSrc="PREV" />
+      {pages}
+      <Icon iconSrc="NEXT" />
+    </Container>
   );
 }

--- a/src/components/common/PageList/pageList.tsx
+++ b/src/components/common/PageList/pageList.tsx
@@ -1,8 +1,10 @@
 import styled from 'styled-components';
 
-import { Box } from '../Layout/Box';
+import { Container } from '@/components/common/Layout/Core';
 
-conTainer;
+import { Box } from '../Layout/Box';
+import { Text } from '../Text';
+
 type PageListType = {
   state: {
     start: number;
@@ -25,7 +27,12 @@ export function PageList({ pageListProps }: PageListProps) {
   const { previous, next, onClickPage } = func;
   return (
     <Box>
-      <></>
+      <Container>
+        <Text>{start}</Text>
+      </Container>
+      <Container>
+        <Text>{end}</Text>
+      </Container>
     </Box>
   );
 }

--- a/src/components/common/PageList/pageList.tsx
+++ b/src/components/common/PageList/pageList.tsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+import { Box } from '../Layout/Box';
+
+conTainer;
+type PageListType = {
+  state: {
+    start: number;
+    end: number;
+    isSkipPage: boolean;
+  };
+  func: {
+    previous: () => void;
+    next: () => void;
+    onClickPage: () => void;
+  };
+};
+type PageListProps = {
+  pageListProps: PageListType;
+};
+
+export function PageList({ pageListProps }: PageListProps) {
+  const { state, func } = pageListProps;
+  const { start, end, isSkipPage } = state;
+  const { previous, next, onClickPage } = func;
+  return (
+    <Box>
+      <></>
+    </Box>
+  );
+}

--- a/src/components/common/PageList/pageList.tsx
+++ b/src/components/common/PageList/pageList.tsx
@@ -61,7 +61,7 @@ export function PageList({
     });
     setFocus(newListStart);
   };
-  const goPrevList = async () => {
+  const goPrevList = () => {
     const newListStart = listStart - skipNumber;
     const newListEnd =
       listEnd === end

--- a/src/components/common/PageList/pageList.tsx
+++ b/src/components/common/PageList/pageList.tsx
@@ -1,25 +1,17 @@
-import styled from 'styled-components';
+import { useState } from 'react';
 
 import { PageNumber } from './PageNumber';
 
 import { Icon } from '../Icon';
 import { Container } from '../Layout/Core';
 
-type PageListType = {
-  state: {
-    start: number;
-    end: number;
-    isSkipPage: boolean;
-  };
-  // func: {
-  //   previous: () => void;
-  //   next: () => void;
-  //   onClickPage: () => void;
-  // };
-};
 type PageListProps = {
-  pageListProps: PageListType;
+  start?: number;
+  end: number;
+  focus: number;
+  skipNumber?: number;
 };
+
 const makePageNumberArr = (start: number, end: number) => {
   const pageNumArr = [];
   for (let i = start; i <= end; i += 1) {
@@ -27,26 +19,74 @@ const makePageNumberArr = (start: number, end: number) => {
   }
   return pageNumArr;
 };
-export function PageList({ pageListProps }: PageListProps) {
-  const { state, func } = pageListProps;
-  const { start, end, isSkipPage } = state;
-  // const { previous, next, onClickPage } = func;
-  const mid = Math.floor((start + end) / 2);
-
+export function PageList({
+  start = 1,
+  end,
+  focus,
+  skipNumber = end,
+}: PageListProps) {
+  const [list, setList] = useState({ listStart: start, listEnd: skipNumber });
+  const { listStart, listEnd } = list;
+  const [listStartNext, listEndPrev] = [listStart + 1, listEnd - 1];
+  const mid = Math.floor((listStart + listEnd) / 2);
   const pageNumberArr = makePageNumberArr(start, end);
-  const pages = !isSkipPage ? (
-    pageNumberArr.map(num => <PageNumber content={num} />)
-  ) : (
-    <>
-      <PageNumber content={start} />
-      <PageNumber content={start + 1} />
-      <PageNumber content="..." />
-      <PageNumber content={mid} />
-      <PageNumber content="..." />
-      <PageNumber content={end - 1} />
-      <PageNumber content={end} />
-    </>
-  );
+
+  const increaseList = (num: number) => {
+    setList({
+      ...list,
+      listStart: listStart + num,
+      listEnd: listEnd + num,
+    });
+  };
+
+  const decreaseList = (num: number) => {
+    setList({
+      ...list,
+      listStart: listStart - num,
+      listEnd: listEnd - num,
+    });
+  };
+
+  const selectModification = (num: number) => {
+    const difference = Math.abs(focus - num);
+    if (num > focus) {
+      increaseList(difference);
+    } else if (num < focus) {
+      decreaseList(difference);
+    }
+  };
+  const onClickPageNumber = (num: number) => () => {
+    if (num !== focus) {
+      selectModification(num);
+    }
+  };
+
+  const pages =
+    skipNumber >= end ? (
+      pageNumberArr.map((num, idx) =>
+        idx + 1 === focus ? (
+          <PageNumber content={num} isFocus />
+        ) : (
+          <PageNumber content={num} onClickPageNumber={onClickPageNumber} />
+        ),
+      )
+    ) : (
+      <>
+        <PageNumber content={listStart} onClickPageNumber={onClickPageNumber} />
+        <PageNumber
+          content={listStartNext}
+          onClickPageNumber={onClickPageNumber}
+        />
+        <PageNumber content="..." />
+        <PageNumber content={mid} isFocus />
+        <PageNumber content="..." />
+        <PageNumber
+          content={listEndPrev}
+          onClickPageNumber={onClickPageNumber}
+        />
+        <PageNumber content={listEnd} onClickPageNumber={onClickPageNumber} />
+      </>
+    );
   return (
     <Container
       backgroundColor="none"

--- a/src/components/server/ProductDetail/OrderForm/index.tsx
+++ b/src/components/server/ProductDetail/OrderForm/index.tsx
@@ -200,9 +200,6 @@ export function Purchase() {
   const orderResponseModal = !!message && (
     <S.OrderConfirmation>{message}</S.OrderConfirmation>
   );
-  const end = 10;
-  const skipNumber = 4;
-  const [focus, setFocus] = useState(1);
 
   return (
     <Modal store={purchaseModalStore} width="50%">
@@ -210,12 +207,6 @@ export function Purchase() {
       <Info info={infoProps} />
       <Option option={optionProps} />
       <Decide decide={decideProps} />
-      <PageList
-        end={end}
-        focus={focus}
-        setFocus={setFocus}
-        skipNumber={skipNumber}
-      />
     </Modal>
   );
 }

--- a/src/components/server/ProductDetail/OrderForm/index.tsx
+++ b/src/components/server/ProductDetail/OrderForm/index.tsx
@@ -7,6 +7,7 @@ import { useSetRecoilState } from 'recoil';
 import { getData, HeaderType } from '@/apis/api';
 import * as API from '@/apis/mainProducts';
 import { Modal } from '@/components/common/Modal';
+import { PageList } from '@/components/common/PageList';
 import { Decide } from '@/components/server/ProductDetail/OrderForm/Decide/Decide';
 import * as S from '@/components/server/ProductDetail/OrderForm/index.style';
 import { Info } from '@/components/server/ProductDetail/OrderForm/Info';
@@ -199,6 +200,9 @@ export function Purchase() {
   const orderResponseModal = !!message && (
     <S.OrderConfirmation>{message}</S.OrderConfirmation>
   );
+  const end = 10;
+  const skipNumber = 4;
+  const [focus, setFocus] = useState(1);
 
   return (
     <Modal store={purchaseModalStore} width="50%">
@@ -206,6 +210,12 @@ export function Purchase() {
       <Info info={infoProps} />
       <Option option={optionProps} />
       <Decide decide={decideProps} />
+      <PageList
+        end={end}
+        focus={focus}
+        setFocus={setFocus}
+        skipNumber={skipNumber}
+      />
     </Modal>
   );
 }


### PR DESCRIPTION
## PR 타입 (복수 선택 가능)
- [x] 구현 사항
- [ ] 버그 수정
- [ ] 환경 설정
- [ ] 리팩토링
- [ ] 기타

## 주요 작업
* 페이지 리스트 구현
* 스킵 유무 따라 다른 ui 구현
* 스킵시 내부에 보여주고 싶은 숫자 컨트롤 구현

## 데모
데모와 주요 데모 코드/ 이미지를 기입합니다. 없어도 되지만 원활한 리뷰를 위해 사용할것을 권장합니다.

## 코드 리뷰어 에게
*  props로 dispatch 함수를 받아야 하는데, stories에서 useState를 사용할 수 없어서 view 적인 모습만 확인할 수 있습니다. 이부분은 제가 좀 더 찾아보고 해결해 볼게요.
* 그래서 component/server/ProductDetail/orderForm의 index.tsx 아랫부분에 코드를 넣어놨습니다. 구매창을 키시면 하단에서 볼 수 있고, 여기서는 이동과 포커싱도 잘 적용되는걸 볼 수 있습니다. index.tsx에서 props를 변경해주면 다른 내용도 테스트 해 볼 수 있습니다! stories에서 상태를 사용하는 이슈가 해결되면 이부분은 제가 지울게요. 
