### PR TITLE
대여 카드 구현

### DIFF
--- a/src/Pages/UserMyPage/RentHistoryCard/RentHistoryCard.stories.tsx
+++ b/src/Pages/UserMyPage/RentHistoryCard/RentHistoryCard.stories.tsx
@@ -1,0 +1,23 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { RentHistoryCard } from './RentHistoryCard';
+
+export default {
+  title: 'View/Test/RentHistoryCard',
+  component: RentHistoryCard,
+} as ComponentMeta<typeof RentHistoryCard>;
+
+const Template: ComponentStory<typeof RentHistoryCard> = args => (
+  <RentHistoryCard {...args} />
+);
+
+export const Default = Template.bind({});
+
+Default.args = {
+  imgSrc: 'https://t1.daumcdn.net/cfile/tistory/24283C3858F778CA2E',
+  productName: '테스트 이름',
+  productPrice: 100000,
+  deliveryRate: 100,
+  rentRate: 50,
+  options: ['1번 옵션', '2번 옵션'],
+};

--- a/src/Pages/UserMyPage/RentHistoryCard/RentHistoryCard.tsx
+++ b/src/Pages/UserMyPage/RentHistoryCard/RentHistoryCard.tsx
@@ -1,0 +1,111 @@
+import styled from 'styled-components';
+
+import { Icon, Text } from '@/components/common';
+import { Line } from '@/components/common/Indicator/Line';
+import { ProgressBar } from '@/components/common/Indicator/ProgressBar';
+import { Box } from '@/components/common/Layout/Box';
+import { Container } from '@/components/common/Layout/Core';
+import { ImageContainer } from '@/components/common/Layout/ImageContainer';
+
+type RentHistoryCardProps = {
+  imgSrc: string;
+  productName: string;
+  options: string[];
+  productPrice: number;
+  deliveryRate: number;
+  rentRate: number;
+  onClickCancel: React.MouseEventHandler;
+};
+
+export function RentHistoryCard({
+  imgSrc,
+  onClickCancel,
+  productName,
+  options,
+  productPrice,
+  deliveryRate,
+  rentRate,
+}: RentHistoryCardProps) {
+  const progressBarHeight = 5;
+  const optionList = options.map(option => (
+    <GreyList key={option}>
+      <Text typography="Light" color="grey3" styles={{ marker: 'grey3' }}>
+        {option}
+      </Text>
+    </GreyList>
+  ));
+  return (
+    <Box
+      boxColor="white"
+      borderColor="secondary"
+      borderWeight={3}
+      size="large"
+      styles={{ position: 'relative', maxWidth: '500px', padding: '10px' }}
+      alignItems="center"
+      justifyContent="space-around"
+      gap={20}
+    >
+      <ImageContainer
+        size="medium"
+        imageSrc={imgSrc}
+        alt="대여 주문 기록 이미지"
+      />
+      <Container
+        flexDirection="column"
+        justifyContent="flex-start"
+        styles={{ width: '30%' }}
+        gap={5}
+      >
+        <Text typography="Light" color="grey3">
+          제품명
+        </Text>
+        <Line />
+        <Text typography="Light" color="grey3">
+          {productName}
+        </Text>
+        <Text typography="Light" color="grey3">
+          옵션
+        </Text>
+        <Line />
+        {optionList}
+      </Container>
+      <Container
+        flexDirection="column"
+        gap={10}
+        styles={{ width: '200px' }}
+        justifyContent="space-between"
+      >
+        <Container flexDirection="column" alignItems="center" gap={10}>
+          <Text>배송 현황</Text>
+          <ProgressBar progressRate={deliveryRate} height={progressBarHeight} />
+        </Container>
+        <Container
+          flexDirection="column"
+          alignItems="center"
+          gap={10}
+          styles={{ marginBottom: '20px' }}
+        >
+          <Text>대여 현황</Text>
+          <ProgressBar progressRate={rentRate} height={progressBarHeight} />
+        </Container>
+        <Container justifyContent="flex-end" alignItems="center">
+          <Text typography="Bold">{productPrice.toLocaleString()}원</Text>
+        </Container>
+      </Container>
+      <CancelBtn iconSrc="CLOSE" onClick={onClickCancel} />
+    </Box>
+  );
+}
+
+const GreyList = styled.li`
+  &::marker {
+    color: ${({ theme }) => theme.pallete.grey3};
+  }
+`;
+export const CancelBtn = styled(Icon)`
+  position: absolute;
+  fill: ${({ theme }) => theme.pallete.grey3};
+  cursor: pointer;
+  top: 10px;
+  right: 10px;
+`;

--- a/src/components/common/Layout/Core/Core.tsx
+++ b/src/components/common/Layout/Core/Core.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unused-prop-types */
 import { ReactNode, forwardRef, Ref } from 'react';
-import styled, { CSSProperties } from 'styled-components';
+import styled, { CSSObject, CSSProperties } from 'styled-components';
 
 export type ContainerProps<T extends RegionalElements> = {
   children?: ReactNode;
@@ -12,6 +12,7 @@ export type ContainerProps<T extends RegionalElements> = {
   backgroundColor?: CSSProperties['backgroundColor'];
   onClick?: React.MouseEventHandler;
   gap?: CSSProperties['gap'];
+  styles?: CSSObject;
 };
 
 type RegionalElements =
@@ -65,6 +66,7 @@ const StyledContainer = styled.div<ContainerProps<RegionalElements>>(
     backgroundColor,
     gap,
     onClick,
+    styles,
   }) => ({
     display: 'flex',
     flexDirection,
@@ -75,6 +77,7 @@ const StyledContainer = styled.div<ContainerProps<RegionalElements>>(
     gap,
     boxSizing: 'border-box',
     cursor: onClick ? 'pointer' : undefined,
+    ...styles,
   }),
 );
 

--- a/src/components/common/Layout/ImageContainer/Default.tsx
+++ b/src/components/common/Layout/ImageContainer/Default.tsx
@@ -48,6 +48,7 @@ const Figure = styled.figure<Pick<ImageContainerProps, 'size'>>(
     height: IMAGE_CONTAINER_SIZE.length[size],
     backgroundColor: theme.pallete.grey5,
     borderRadius: '50%',
+    margin: 0,
   }),
 );
 


### PR DESCRIPTION
## PR 타입 (복수 선택 가능)
- [x] 구현 사항
- [ ] 버그 수정
- [ ] 환경 설정
- [x] 리팩토링
- [ ] 기타

## 주요 작업
* 대여 카드 구현

## 데모
![K-216](https://user-images.githubusercontent.com/54533561/206979920-a7920c11-696e-45d7-b4ce-dc77b1dc3441.png)



## 코드 리뷰어 에게
* 디자인 시스템의 figure 컴포넌트에 기본으로 걸려있는 margin 값을 없애기 위해 margin=0을 추가했습니다
* container 컴포넌트에 styles props가 적용되있지 않아 추가했습니다
* OrderHistoryCard 컴포넌트를 한번 확인해달라 하셔서 확인해봤는데, 오타와 min-width 만 조정해주면 될 것 같아요!
* 정기 회의에서 결정된 문제 제보 버튼을 제거하면서 ui를 좀 더 깔끔하게 수정했습니다